### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-sensors10 (9.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 20:59:51 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/copyright

--- a/jammy/debian/libgz-sensors10-air-pressure-dev.install
+++ b/jammy/debian/libgz-sensors10-air-pressure-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-air-pressure-dev.install

--- a/jammy/debian/libgz-sensors10-air-pressure.install
+++ b/jammy/debian/libgz-sensors10-air-pressure.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-air-pressure.install

--- a/jammy/debian/libgz-sensors10-air-speed-dev.install
+++ b/jammy/debian/libgz-sensors10-air-speed-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-air-speed-dev.install

--- a/jammy/debian/libgz-sensors10-air-speed.install
+++ b/jammy/debian/libgz-sensors10-air-speed.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-air-speed.install

--- a/jammy/debian/libgz-sensors10-altimeter-dev.install
+++ b/jammy/debian/libgz-sensors10-altimeter-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-altimeter-dev.install

--- a/jammy/debian/libgz-sensors10-altimeter.install
+++ b/jammy/debian/libgz-sensors10-altimeter.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-altimeter.install

--- a/jammy/debian/libgz-sensors10-boundingbox-camera-dev.install
+++ b/jammy/debian/libgz-sensors10-boundingbox-camera-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-boundingbox-camera-dev.install

--- a/jammy/debian/libgz-sensors10-boundingbox-camera.install
+++ b/jammy/debian/libgz-sensors10-boundingbox-camera.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-boundingbox-camera.install

--- a/jammy/debian/libgz-sensors10-camera-dev.install
+++ b/jammy/debian/libgz-sensors10-camera-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-camera-dev.install

--- a/jammy/debian/libgz-sensors10-camera.install
+++ b/jammy/debian/libgz-sensors10-camera.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-camera.install

--- a/jammy/debian/libgz-sensors10-core-dev.install
+++ b/jammy/debian/libgz-sensors10-core-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-core-dev.install

--- a/jammy/debian/libgz-sensors10-depth-camera-dev.install
+++ b/jammy/debian/libgz-sensors10-depth-camera-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-depth-camera-dev.install

--- a/jammy/debian/libgz-sensors10-depth-camera.install
+++ b/jammy/debian/libgz-sensors10-depth-camera.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-depth-camera.install

--- a/jammy/debian/libgz-sensors10-dev.install
+++ b/jammy/debian/libgz-sensors10-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-dev.install

--- a/jammy/debian/libgz-sensors10-dvl-dev.install
+++ b/jammy/debian/libgz-sensors10-dvl-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-dvl-dev.install

--- a/jammy/debian/libgz-sensors10-dvl.install
+++ b/jammy/debian/libgz-sensors10-dvl.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-dvl.install

--- a/jammy/debian/libgz-sensors10-force-torque-dev.install
+++ b/jammy/debian/libgz-sensors10-force-torque-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-force-torque-dev.install

--- a/jammy/debian/libgz-sensors10-force-torque.install
+++ b/jammy/debian/libgz-sensors10-force-torque.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-force-torque.install

--- a/jammy/debian/libgz-sensors10-gpu-lidar-dev.install
+++ b/jammy/debian/libgz-sensors10-gpu-lidar-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-gpu-lidar-dev.install

--- a/jammy/debian/libgz-sensors10-gpu-lidar.install
+++ b/jammy/debian/libgz-sensors10-gpu-lidar.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-gpu-lidar.install

--- a/jammy/debian/libgz-sensors10-imu-dev.install
+++ b/jammy/debian/libgz-sensors10-imu-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-imu-dev.install

--- a/jammy/debian/libgz-sensors10-imu.install
+++ b/jammy/debian/libgz-sensors10-imu.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-imu.install

--- a/jammy/debian/libgz-sensors10-lidar-dev.install
+++ b/jammy/debian/libgz-sensors10-lidar-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-lidar-dev.install

--- a/jammy/debian/libgz-sensors10-lidar.install
+++ b/jammy/debian/libgz-sensors10-lidar.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-lidar.install

--- a/jammy/debian/libgz-sensors10-logical-camera-dev.install
+++ b/jammy/debian/libgz-sensors10-logical-camera-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-logical-camera-dev.install

--- a/jammy/debian/libgz-sensors10-logical-camera.install
+++ b/jammy/debian/libgz-sensors10-logical-camera.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-logical-camera.install

--- a/jammy/debian/libgz-sensors10-magnetometer-dev.install
+++ b/jammy/debian/libgz-sensors10-magnetometer-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-magnetometer-dev.install

--- a/jammy/debian/libgz-sensors10-magnetometer.install
+++ b/jammy/debian/libgz-sensors10-magnetometer.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-magnetometer.install

--- a/jammy/debian/libgz-sensors10-navsat-dev.install
+++ b/jammy/debian/libgz-sensors10-navsat-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-navsat-dev.install

--- a/jammy/debian/libgz-sensors10-navsat.install
+++ b/jammy/debian/libgz-sensors10-navsat.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-navsat.install

--- a/jammy/debian/libgz-sensors10-rendering-dev.install
+++ b/jammy/debian/libgz-sensors10-rendering-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-rendering-dev.install

--- a/jammy/debian/libgz-sensors10-rendering.install
+++ b/jammy/debian/libgz-sensors10-rendering.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-rendering.isntall

--- a/jammy/debian/libgz-sensors10-rgbd-camera-dev.install
+++ b/jammy/debian/libgz-sensors10-rgbd-camera-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-rgbd-camera-dev.install

--- a/jammy/debian/libgz-sensors10-rgbd-camera.install
+++ b/jammy/debian/libgz-sensors10-rgbd-camera.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-rgbd-camera.install

--- a/jammy/debian/libgz-sensors10-segmentation-camera-dev.install
+++ b/jammy/debian/libgz-sensors10-segmentation-camera-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-segmentation-camera-dev.install

--- a/jammy/debian/libgz-sensors10-segmentation-camera.install
+++ b/jammy/debian/libgz-sensors10-segmentation-camera.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-segmentation-camera.install

--- a/jammy/debian/libgz-sensors10-thermal-camera-dev.install
+++ b/jammy/debian/libgz-sensors10-thermal-camera-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-thermal-camera-dev.install

--- a/jammy/debian/libgz-sensors10-thermal-camera.install
+++ b/jammy/debian/libgz-sensors10-thermal-camera.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-thermal-camera.install

--- a/jammy/debian/libgz-sensors10-wide-angle-camera-dev.install
+++ b/jammy/debian/libgz-sensors10-wide-angle-camera-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-wide-angle-camera-dev.install

--- a/jammy/debian/libgz-sensors10-wide-angle-camera.install
+++ b/jammy/debian/libgz-sensors10-wide-angle-camera.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors-wide-angle-camera.install

--- a/jammy/debian/libgz-sensors10.install
+++ b/jammy/debian/libgz-sensors10.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sensors.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.